### PR TITLE
fix batch_size for acending_all y_sampler

### DIFF
--- a/src/utils/sample.py
+++ b/src/utils/sample.py
@@ -68,6 +68,7 @@ def sample_y(y_sampler, batch_size, num_classes, device):
 
 def sample_zy(z_prior, batch_size, z_dim, num_classes, truncation_factor, y_sampler, radius, device):
     fake_labels = sample_y(y_sampler=y_sampler, batch_size=batch_size, num_classes=num_classes, device=device)
+    batch_size = fake_labels.shape[0]
 
     if z_prior == "gaussian":
         zs = sample_normal(batch_size=batch_size, z_dim=z_dim, truncation_factor=truncation_factor, device=device)
@@ -109,6 +110,7 @@ def generate_images(z_prior, truncation_factor, batch_size, z_dim, num_classes, 
                                         y_sampler=y_sampler,
                                         radius=radius,
                                         device=device)
+    batch_size = fake_labels.shape[0]
     info_discrete_c, info_conti_c = None, None
     if MODEL.info_type in ["discrete", "both"]:
         info_discrete_c = torch.randint(MODEL.info_dim_discrete_c,(batch_size, MODEL.info_num_discrete_c), device=device)


### PR DESCRIPTION
Starting from commit https://github.com/POSTECH-CVLab/PyTorch-StudioGAN/commit/f5dad2003c5b5983b23f9cb1652db858ee8cb78a, `sample_latents` was split into two parts, `sample_y` and `sample_zy`. When `y_sampler == "acending_all"`, the updated `batch_size` in `sample_y` is not passed to `sample_zy` and the latter part of `generate_images`, causing dimension mismatch for `zs`, `fake_labels` etc.
https://github.com/POSTECH-CVLab/PyTorch-StudioGAN/blob/1bcc2c124b853ddc99d3ba42751c02d2afd4564c/src/utils/sample.py#L52-L53

This PR fixed this issue by setting `batch_size` based on the shape of returned `fake_labels` after calling `sample_y` and `sample_zy` to guarantee consistency.